### PR TITLE
Fix typo calling endpoint url for register auth

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -89,7 +89,7 @@ type RegisterParams struct {
 }
 
 func (a *AuthClient) Register(body RegisterParams) (*AuthResponse, *KontenbaseError) {
-	resp, err := a.httpClient.Post("/logout", body, nil)
+	resp, err := a.httpClient.Post("/register", body, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Typo calling url api endpoint, in go sdk auth register call endpoint like this `/logout` and in javascript sdk call endpoint for register like this `/register`.

## js sdk

```js
async register<T = any>(body: {
    firstName: string;
    lastName?: string;
    email: string;
    password: string;
    role?: string;
  }): Promise<AuthResponse<T>> {
    return new Promise(async (resolve, _reject) => {
      try {
        const { data, status, statusText } = await axios.post<TokenResponse<T>>(
          `${this.url}/auth/register`,
          body,
        );
        this.saveToken(data.token);

        const user = data.user;
        resolve({
          user,
          status,
          statusText,
          token: data.token,
        });
      } catch (error) {
        resolve(this._error(error));
      }
    });
  }
```
 
 ##  go sdk
 
```go
func (a *AuthClient) Register(body RegisterParams) (*AuthResponse, *KontenbaseError) {
	resp, err := a.httpClient.Post("/logout", body, nil) // typo here
	if err != nil {
		return nil, err
	}
```